### PR TITLE
#38: Add ability to modify applicable promotion fields while promotion is active

### DIFF
--- a/src/Feature/Promotions/Engine/ConfigureSitecore.cs
+++ b/src/Feature/Promotions/Engine/ConfigureSitecore.cs
@@ -28,8 +28,19 @@ namespace Feature.Promotions.Engine
                     .Replace<DoActionAddQualificationBlock, Pipelines.Blocks.DoActionAddQualificationBlock>()
                     .Replace<DoActionAddBenefitBlock, Pipelines.Blocks.DoActionAddBenefitBlock>()
                 )
-                
-            );
+				
+				.ConfigurePipeline<IPopulateEntityViewActionsPipeline>(builder => builder
+					.Add<Pipelines.Blocks.PopulatePromotionViewActionsBlock>().After<PopulatePromotionViewActionsBlock>()
+				)
+
+				.ConfigurePipeline<IGetEntityViewPipeline>(builder => builder
+					.Add<Pipelines.Blocks.GetPromotionDetailsViewBlock>().After<GetPromotionDetailsViewBlock>()
+				)
+
+				.ConfigurePipeline<IEditPromotionPipeline>(builder => builder
+					.Replace<EditPromotionBlock, Pipelines.Blocks.EditPromotionBlock>()
+				)
+			);
         }
     }
 }

--- a/src/Feature/Promotions/Engine/Pipelines/Blocks/EditPromotionBlock.cs
+++ b/src/Feature/Promotions/Engine/Pipelines/Blocks/EditPromotionBlock.cs
@@ -1,0 +1,127 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="EditPromotionBlock.cs" company="Sitecore Corporation">
+//   Copyright (c) Sitecore Corporation 1999-2019
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace Feature.Promotions.Engine.Pipelines.Blocks
+{
+	using Sitecore.Commerce.Core;
+	using Sitecore.Commerce.Plugin.ManagedLists;
+	using Sitecore.Commerce.Plugin.Promotions;
+	using Sitecore.Framework.Conditions;
+	using Sitecore.Framework.Pipelines;
+	using System;
+	using System.Threading.Tasks;
+	using PromotionsConstants = Feature.Promotions.Engine.PromotionsConstants;
+
+	/// <summary>Edits the promotion entity.</summary>
+	/// <seealso>
+	///     <cref>
+	///         Sitecore.Framework.Pipelines.PipelineBlock{Sitecore.Commerce.Plugin.Promotions.EditPromotionArgument,
+	///         Sitecore.Commerce.Plugin.Promotions.Promotion, Sitecore.Commerce.Core.CommercePipelineExecutionContext}
+	///     </cref>
+	/// </seealso>
+	[PipelineDisplayName(PromotionsConstants.Pipelines.Blocks.EditPromotion)]
+	public class EditPromotionBlock : PipelineBlock<EditPromotionArgument, Promotion, CommercePipelineExecutionContext>
+	{
+		/// <inheritdoc />
+		/// <summary>Initializes a new instance of the <see cref="T:Sitecore.Framework.Pipelines.PipelineBlock" /> class.</summary>
+		public EditPromotionBlock()
+		  : base(null)
+		{
+		}
+
+		/// <summary>The run.</summary>
+		/// <param name="EditPromotionArgument">The <see cref="EditPromotionArgument"/>.</param>
+		/// <param name="context">The context.</param>
+		/// <returns>The <see cref="Promotion"/>.</returns>
+		public override async Task<Promotion> Run(EditPromotionArgument arg, CommercePipelineExecutionContext context)
+		{
+			Condition.Requires(arg).IsNotNull($"{Name}: The block's argument cannot be null.");
+			Condition.Requires(arg.Promotion).IsNotNull($"{Name}: The promotion cannot be null.");
+			Condition.Requires(arg.ValidFrom).IsNotNull($"{Name}: The promotion's valid from date cannot be null.");
+			Condition.Requires(arg.ValidTo).IsNotNull($"{Name}: The promotion's valid to date cannot be null.");
+			Condition.Requires(arg.Text).IsNotNullOrEmpty($"{Name}: The promotion's text cannot be null or empty.");
+			Condition.Requires(arg.CartText).IsNotNullOrEmpty($"{Name}: The promotion's cart text cannot be null or empty.");
+
+			var promotion = arg.Promotion;
+			var effectiveDate = context.CommerceContext.CurrentEffectiveDate();
+			if (arg.ValidTo.CompareTo(effectiveDate) <= 0)
+			{
+				context.Abort(
+					await context.CommerceContext.AddMessage(
+						context.GetPolicy<KnownResultCodes>().Error,
+						"ValidToDateInPast",
+						new object[] { promotion.FriendlyId },
+						$"'{promotion.FriendlyId}' cannot be edited because Valid To date is in the past."),
+					context);
+
+				return null;
+			}
+
+			if (!promotion.IsDraft(context.CommerceContext) && promotion.ValidTo.CompareTo(effectiveDate) <= 0)
+			{
+				context.Abort(
+					await context.CommerceContext.AddMessage(
+						context.GetPolicy<KnownResultCodes>().Error,
+						"EntityIsApproved",
+						new object[] { promotion.FriendlyId },
+						$"'{promotion.FriendlyId}' cannot be edited or deleted because is approved and has past the promotion's Valid To date."),
+					context);
+
+				return null;
+			}
+
+			if (promotion.HasPolicy<DisabledPolicy>())
+			{
+				context.Abort(
+					await context.CommerceContext.AddMessage(
+						context.GetPolicy<KnownResultCodes>().Error,
+						"EntityIsDisabled",
+						new object[] { promotion.FriendlyId },
+						$"'{promotion.FriendlyId}' cannot be edited or deleted because is disabled."),
+					context);
+
+				return null;
+			}
+
+			if (DateTimeOffset.Compare(arg.ValidTo, arg.ValidFrom) <= 0)
+			{
+				context.Abort(
+					await context.CommerceContext.AddMessage(
+						context.GetPolicy<KnownResultCodes>().Error,
+						"InvalidDateRange",
+						null,
+						$"Invalid date range.'{arg.ValidTo}' cannot be earlier than '{arg.ValidFrom}'"),
+					context);
+
+				return promotion;
+			}
+
+			promotion.ValidFrom = arg.ValidFrom;
+			promotion.ValidTo = arg.ValidTo;
+			promotion.Description = arg.Description;
+			promotion.DisplayName = arg.DisplayName;
+			promotion.DisplayCartText = arg.CartText;
+			promotion.DisplayText = arg.Text;
+
+			if (arg.IsExclusive)
+			{
+				promotion.SetPolicy(new ExclusivePromotionPolicy());
+			}
+			else if (promotion.HasPolicy<ExclusivePromotionPolicy>())
+			{
+				promotion.Policies.Remove(promotion.GetPolicy<ExclusivePromotionPolicy>());
+			}
+
+			var component = promotion.GetComponent<TransientListMembershipsComponent>();
+			if (component != null)
+			{
+				component.Memberships.Add(context.GetPolicy<KnownPromotionsListsPolicy>().PromotionsIndex);
+			}
+
+			return promotion;
+		}
+	}
+}

--- a/src/Feature/Promotions/Engine/Pipelines/Blocks/GetPromotionDetailsViewBlock.cs
+++ b/src/Feature/Promotions/Engine/Pipelines/Blocks/GetPromotionDetailsViewBlock.cs
@@ -1,0 +1,74 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="GetPromotionDetailsViewBlock.cs" company="Sitecore Corporation">
+//   Copyright (c) Sitecore Corporation 1999-2019
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace Feature.Promotions.Engine.Pipelines.Blocks
+{
+	using Sitecore.Commerce.Core;
+	using Sitecore.Commerce.EntityViews;
+	using Sitecore.Commerce.Plugin.Promotions;
+	using Sitecore.Framework.Conditions;
+	using Sitecore.Framework.Pipelines;
+	using System;
+	using System.Collections.Generic;
+	using System.Linq;
+	using System.Threading.Tasks;
+	using PromotionsConstants = Feature.Promotions.Engine.PromotionsConstants;
+
+	/// <summary>Updates the promotion details view to restrict certain view properties from being editable.</summary>
+	/// <seealso>
+	///     <cref>
+	///         Sitecore.Framework.Pipelines.PipelineBlock{Sitecore.Commerce.EntityViews.EntityView,
+	///         Sitecore.Commerce.EntityViews.EntityView, Sitecore.Commerce.Core.CommercePipelineExecutionContext}
+	///     </cref>
+	/// </seealso>
+	[PipelineDisplayName(PromotionsConstants.Pipelines.Blocks.GetPromotionDetailsView)]
+	public class GetPromotionDetailsViewBlock : PipelineBlock<EntityView, EntityView, CommercePipelineExecutionContext>
+	{
+		/// <inheritdoc />
+		/// <summary>Initializes a new instance of the <see cref="T:Sitecore.Framework.Pipelines.PipelineBlock" /> class.</summary>
+		public GetPromotionDetailsViewBlock()
+		  : base(null)
+		{
+		}
+
+		/// <summary>The run.</summary>
+		/// <param name="entityView">The <see cref="EntityView"/>.</param>
+		/// <param name="context">The context.</param>
+		/// <returns>The <see cref="EntityView"/>.</returns>
+		public override Task<EntityView> Run(EntityView entityView, CommercePipelineExecutionContext context)
+		{
+			Condition.Requires(entityView).IsNotNull($"{Name}: The argument cannot be null");
+
+			var entityViewArgument = context.CommerceContext.GetObject<EntityViewArgument>();
+			if (string.IsNullOrEmpty(entityViewArgument?.ViewName)
+					|| !entityViewArgument.ViewName.Equals(context.GetPolicy<KnownPromotionsViewsPolicy>().Details, StringComparison.OrdinalIgnoreCase)
+					&& !entityViewArgument.ViewName.Equals(context.GetPolicy<KnownPromotionsViewsPolicy>().Master, StringComparison.OrdinalIgnoreCase))
+			{
+				return Task.FromResult(entityView);
+			}
+
+			var isEditAction = entityViewArgument.ForAction.Equals(context.GetPolicy<KnownPromotionsActionsPolicy>().EditPromotion, StringComparison.OrdinalIgnoreCase);
+			if (!(entityViewArgument.Entity is Promotion) || !isEditAction)
+			{
+				return Task.FromResult(entityView);
+			}
+
+			var promotion = (Promotion)entityViewArgument.Entity;
+			var effectiveDate = context.CommerceContext.CurrentEffectiveDate();
+			if (promotion.IsDraft(context.CommerceContext)
+					|| promotion.ValidTo.CompareTo(effectiveDate) <= 0
+					|| promotion.HasPolicy<DisabledPolicy>())
+			{
+				return Task.FromResult(entityView);
+			}
+
+			entityView.Properties.Where(p => p.Name == "ValidFrom").ForEach(prop => { prop.IsHidden = true; });
+			entityView.Properties.Where(p => p.Name == "IsExclusive").ForEach(prop => { prop.IsReadOnly = true; });
+
+			return Task.FromResult(entityView);
+		}
+	}
+}

--- a/src/Feature/Promotions/Engine/Pipelines/Blocks/GetPromotionDetailsViewBlock.cs
+++ b/src/Feature/Promotions/Engine/Pipelines/Blocks/GetPromotionDetailsViewBlock.cs
@@ -65,8 +65,8 @@ namespace Feature.Promotions.Engine.Pipelines.Blocks
 				return Task.FromResult(entityView);
 			}
 
-			entityView.Properties.Where(p => p.Name == "ValidFrom").ForEach(prop => { prop.IsHidden = true; });
-			entityView.Properties.Where(p => p.Name == "IsExclusive").ForEach(prop => { prop.IsReadOnly = true; });
+			entityView.GetProperty("ValidFrom").IsHidden = true;
+			entityView.GetProperty("IsExclusive").IsReadOnly = true;
 
 			return Task.FromResult(entityView);
 		}

--- a/src/Feature/Promotions/Engine/Pipelines/Blocks/PopulatePromotionViewActionsBlock.cs
+++ b/src/Feature/Promotions/Engine/Pipelines/Blocks/PopulatePromotionViewActionsBlock.cs
@@ -1,0 +1,78 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="PopulatePromotionViewActionsBlock.cs" company="Sitecore Corporation">
+//   Copyright (c) Sitecore Corporation 1999-2019
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace Feature.Promotions.Engine.Pipelines.Blocks
+{
+	using Sitecore.Commerce.Core;
+	using Sitecore.Commerce.EntityViews;
+	using Sitecore.Commerce.Plugin.BusinessUsers;
+	using Sitecore.Commerce.Plugin.Promotions;
+	using Sitecore.Framework.Pipelines;
+	using System;
+	using System.Linq;
+	using System.Threading.Tasks;
+	using PromotionsConstants = Feature.Promotions.Engine.PromotionsConstants;
+
+	/// <summary>Enables the 'Edit' and 'Localize' view actions if the promotion is active (current
+	/// date prior to 'Valid To' date and promotion has not been disabled.)</summary>
+	/// <seealso>
+	///     <cref>
+	///         Sitecore.Framework.Pipelines.PipelineBlock{Sitecore.Commerce.EntityViews.EntityView,
+	///         Sitecore.Commerce.EntityViews.EntityView, Sitecore.Commerce.Core.CommercePipelineExecutionContext}
+	///     </cref>
+	/// </seealso>
+	[PipelineDisplayName(PromotionsConstants.Pipelines.Blocks.PopulatePromotionViewActions)]
+	public class PopulatePromotionViewActionsBlock : PipelineBlock<EntityView, EntityView, CommercePipelineExecutionContext>
+	{
+		/// <inheritdoc />
+		/// <summary>Initializes a new instance of the <see cref="T:Sitecore.Framework.Pipelines.PipelineBlock" /> class.</summary>
+		public PopulatePromotionViewActionsBlock()
+		  : base(null)
+		{
+		}
+
+		/// <summary>The run.</summary>
+		/// <param name="entityView">The <see cref="EntityView"/>.</param>
+		/// <param name="context">The context.</param>
+		/// <returns>The <see cref="EntityView"/>.</returns>
+		public override Task<EntityView> Run(EntityView entityView, CommercePipelineExecutionContext context)
+		{
+			if (string.IsNullOrEmpty(entityView?.Name)
+				|| !entityView.Name.Equals(context.GetPolicy<KnownPromotionsViewsPolicy>().Details, StringComparison.OrdinalIgnoreCase)
+				|| !string.IsNullOrEmpty(entityView.Action))
+			{
+				return Task.FromResult(entityView);
+			}
+
+			var entityViewArgument = context.CommerceContext.GetObjects<EntityViewArgument>().FirstOrDefault();
+			var promotion = entityViewArgument?.Entity as Promotion;
+			if (promotion == null)
+			{
+				return Task.FromResult(entityView);
+			}
+
+			var effectiveDate = context.CommerceContext.CurrentEffectiveDate();
+			var actionsPolicy = entityView.GetPolicy<ActionsPolicy>();
+			var editAction = actionsPolicy.Actions.FirstOrDefault(p => p.Name.Equals(context.GetPolicy<KnownPromotionsActionsPolicy>().EditPromotion, StringComparison.OrdinalIgnoreCase));
+			if (editAction != null)
+			{
+				editAction.IsEnabled = promotion.ValidTo.CompareTo(effectiveDate) > 0 && !promotion.HasPolicy<DisabledPolicy>();
+			}
+			
+			var localizeAction = actionsPolicy.Actions.FirstOrDefault(a => a.Name.Equals(context.GetPolicy<KnownBusinessUsersActionsPolicy>().LocalizeProperty, StringComparison.OrdinalIgnoreCase));
+			if (localizeAction != null)
+			{
+				localizeAction.IsEnabled = promotion.ValidTo.CompareTo(effectiveDate) > 0 && !promotion.HasPolicy<DisabledPolicy>();
+				if (localizeAction.HasPolicy<MultiStepActionPolicy>())
+				{
+					localizeAction.GetPolicy<MultiStepActionPolicy>().FirstStep.IsEnabled = promotion.ValidTo.CompareTo(effectiveDate) > 0 && !promotion.HasPolicy<DisabledPolicy>();
+				}
+			}
+
+			return Task.FromResult(entityView);
+		}
+	}
+}

--- a/src/Feature/Promotions/Engine/PromotionsConstants.cs
+++ b/src/Feature/Promotions/Engine/PromotionsConstants.cs
@@ -10,6 +10,16 @@
         public static class Actions
         {
             public const string CartItemTargetItemsCollectionSubtotalPercentOffAction = nameof(CartItemTargetItemsCollectionSubtotalPercentOffAction);
-        }
-    }
+		}
+
+		public static class Pipelines
+		{
+			public static class Blocks
+			{
+				public const string EditPromotion = "Promotions.Block.EditPromotion";
+				public const string GetPromotionDetailsView = "Promotions.Block.GetPromotionDetailsView";
+				public const string PopulatePromotionViewActions = "Promotions.Block.PopulatePromotionViewActions";
+			}
+		}
+	}
 }


### PR DESCRIPTION
Technical Details:
- Added ability to edit promotion details, localisation properties, and Valid To date while promotion is still active (current date is before Valid To date and promotion is not disabled)